### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -11,10 +11,6 @@
 		"authorList": ["GWYOG", "bartimaeusnek"],
 		"credits": "",
 		"logoFile": "",
-		"screenshots": [],
-		"requiredMods": ["Forge", "gregtech", "NotEnoughItems"],
-		"dependencies": ["gregtech", "NotEnoughItems"],
-		"dependants": [],
-		"useDependencyInformation": true
+		"screenshots": []
 	}]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.